### PR TITLE
DynamicMethodProvider.GetAction can call methods with return values, and...

### DIFF
--- a/Serializer/Objects/DynamicMethodProvider.cs
+++ b/Serializer/Objects/DynamicMethodProvider.cs
@@ -131,6 +131,7 @@ namespace ForSerial.Objects
                 .LoadObjectInstance(method.DeclaringType)
                 .LoadParamsFromObjectArrayArg(1, method)
                 .CallMethod(method)
+                .IgnoreReturnValue(method)
                 .Return();
 
             return (ActionMethod)dynamicMethod.CreateDelegate(typeof(ActionMethod));
@@ -289,6 +290,13 @@ namespace ForSerial.Objects
         {
             if (type.IsValueType)
                 il.Emit(OpCodes.Unbox_Any, type);
+            return il;
+        }
+
+        public static ILGenerator IgnoreReturnValue(this ILGenerator il, MethodInfo method)
+        {
+            if (method.ReturnType != typeof(void))
+                il.Emit(OpCodes.Pop);
             return il;
         }
 

--- a/Tests/Objects/Output/DynamicMethodProviderClassTests.cs
+++ b/Tests/Objects/Output/DynamicMethodProviderClassTests.cs
@@ -22,6 +22,7 @@ namespace ForSerial.Tests.Objects
         private readonly MethodInfo privateValueMethod = typeof(Class).GetMethod("PrivateValueMethod", PrivateInstanceMembers, null, new[] { typeof(int) }, new ParameterModifier[] { });
         private readonly MethodInfo publicClassMethod = typeof(Class).GetMethod("PublicClassMethod", new[] { typeof(object) });
         private readonly MethodInfo privateClassMethod = typeof(Class).GetMethod("PrivateClassMethod", PrivateInstanceMembers, null, new[] { typeof(object) }, new ParameterModifier[] { });
+        private readonly MethodInfo publicClassMethodWithReturnValue = typeof(Class).GetMethod("PublicClassMethodWithReturnValue", new[] { typeof(object) });
 
         [Test]
         public void GetPublicValueProperty()
@@ -245,6 +246,18 @@ namespace ForSerial.Tests.Objects
             Assert.AreSame(expected, instance.GetPrivateClassField());
         }
 
+        [Test]
+        public void CallPublicClassMethodWithReturnValue()
+        {
+            Class instance = new Class();
+            object expected = new object();
+
+            ActionMethod result = sut.GetAction(publicClassMethodWithReturnValue);
+
+            result(instance, new[] { expected });
+            Assert.AreSame(expected, instance.GetPrivateClassField());
+        }
+
         private class Class
         {
             public Class(int privateValueField = 0, object privateClassField = null, int privateValueProperty = 0, object privateClassProperty = null)
@@ -283,6 +296,12 @@ namespace ForSerial.Tests.Objects
             private void PrivateClassMethod(object obj)
             {
                 privateClassField = obj;
+            }
+
+            public object PublicClassMethodWithReturnValue(object obj)
+            {
+                PublicClassMethod(obj);
+                return obj;
             }
 
             public int PublicValueField;

--- a/Tests/Objects/Output/ObjectWriterTests.cs
+++ b/Tests/Objects/Output/ObjectWriterTests.cs
@@ -920,6 +920,13 @@ namespace ForSerial.Tests.Objects
             public int Value { get; private set; }
         }
 
+        [Test]
+        public void HashSet()
+        {
+            Clone(new HashSet<string> { "foo" })
+                .ShouldMatch("foo");
+        }
+
 
         private static T Clone<T>(T obj)
         {


### PR DESCRIPTION
... just ignores the return value.
